### PR TITLE
Added Access Restricion for Boss, and for Journalist Job only.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -2,26 +2,26 @@ ESX = nil
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
-RegisterCommand("cam", function(source, args, raw)
-    local src = source
+RegisterCommand("cam", function(source, args, raw)          -- Camera Man and Boss Access only
+    local src = source                                      -- Added 'xPlayer.job.name == 'Journalist' to prevent other jobs from accessing said props.'
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.grade == 1 then
+    if xPlayer ~= nil and xPlayer.job.grade == 1 or xPlayer.job.grade == 4 and xPlayer.job.name == 'Journalist' then
         TriggerClientEvent("Cam:ToggleCam", src)
     end 
 end)
 
-RegisterCommand("bmic", function(source, args, raw)
+RegisterCommand("bmic", function(source, args, raw)         -- Crew Access and Boss Access only
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.grade == 0 then
+    if xPlayer ~= nil and xPlayer.job.grade == 0 or xPlayer.job.grade == 4 and xPlayer.job.name == 'Journalist' then
         TriggerClientEvent("Mic:ToggleBMic", src)
     end
 end)
 
-RegisterCommand("mic", function(source, args, raw)
+RegisterCommand("mic", function(source, args, raw)          -- Anchor, Reporter Access and Boss Access only
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.grade == 2 then
+    if xPlayer ~= nil and xPlayer.job.grade == 2 or xPlayer.job.grade == 3 or xPlayer.job.grade == 4 and xPlayer.job.name == 'Journalist' then
         TriggerClientEvent("Mic:ToggleMic", src)
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,23 +5,29 @@ TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 RegisterCommand("cam", function(source, args, raw)          -- Camera Man and Boss Access only
     local src = source                                      -- Added 'xPlayer.job.name == 'Journalist' to prevent other jobs from accessing said props.'
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.grade == 1 or xPlayer.job.grade == 4 and xPlayer.job.name == 'Journalist' then
-        TriggerClientEvent("Cam:ToggleCam", src)
+    if xPlayer ~= nil and xPlayer.job.name == 'Journalist' then
+        if xPlayer.job.grade == 1 or xPlayer.job.grade == 4 then
+        TriggerClientEvent("Mic:ToggleBMic", src)
+        end
     end 
 end)
 
 RegisterCommand("bmic", function(source, args, raw)         -- Crew Access and Boss Access only
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.grade == 0 or xPlayer.job.grade == 4 and xPlayer.job.name == 'Journalist' then
+    if xPlayer ~= nil and xPlayer.job.name == 'Journalist' then
+        if xPlayer.job.grade == 0 or xPlayer.job.grade == 4 then
         TriggerClientEvent("Mic:ToggleBMic", src)
+        end
     end
 end)
 
 RegisterCommand("mic", function(source, args, raw)          -- Anchor, Reporter Access and Boss Access only
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.grade == 2 or xPlayer.job.grade == 3 or xPlayer.job.grade == 4 and xPlayer.job.name == 'Journalist' then
+    if xPlayer ~= nil and xPlayer.job.name == 'Journalist' then
+        if xPlayer.job.grade == 2 or xPlayer.job.grade == 3 or xPlayer.job.grade == 4 then
         TriggerClientEvent("Mic:ToggleMic", src)
+        end
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,7 +5,7 @@ TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 RegisterCommand("cam", function(source, args, raw)          -- Camera Man and Boss Access only
     local src = source                                      -- Added 'xPlayer.job.name == 'Journalist' to prevent other jobs from accessing said props.'
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.name == 'Journalist' then
+    if xPlayer ~= nil and xPlayer.job.name == 'journalist' then
         if xPlayer.job.grade == 1 or xPlayer.job.grade == 4 then
         TriggerClientEvent("Mic:ToggleBMic", src)
         end
@@ -15,7 +15,7 @@ end)
 RegisterCommand("bmic", function(source, args, raw)         -- Crew Access and Boss Access only
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.name == 'Journalist' then
+    if xPlayer ~= nil and xPlayer.job.name == 'journalist' then
         if xPlayer.job.grade == 0 or xPlayer.job.grade == 4 then
         TriggerClientEvent("Mic:ToggleBMic", src)
         end
@@ -25,7 +25,7 @@ end)
 RegisterCommand("mic", function(source, args, raw)          -- Anchor, Reporter Access and Boss Access only
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if xPlayer ~= nil and xPlayer.job.name == 'Journalist' then
+    if xPlayer ~= nil and xPlayer.job.name == 'journalist' then
         if xPlayer.job.grade == 2 or xPlayer.job.grade == 3 or xPlayer.job.grade == 4 then
         TriggerClientEvent("Mic:ToggleMic", src)
         end


### PR DESCRIPTION
We tested /bmic and other Weazel news Commands earlier, other jobs with the rank grade 0, 1, and 2 had access to the said props. Added restriction for Journalist access only. Given all prop access for boss. 